### PR TITLE
Prevent premature auto switch when target time already passed

### DIFF
--- a/expo2025-reserver-android.user.js
+++ b/expo2025-reserver-android.user.js
@@ -315,7 +315,8 @@ function checkAutoSwitch(now){
   const base=now instanceof Date?now:serverNow();
   const target=new Date(base.getTime());
   target.setHours(hh,mm,0,0);
-  if(base.getTime()>=target.getTime())triggerSwitchToBooking();
+  const diff=base.getTime()-target.getTime();
+  if(diff>=0&&diff<12*60*60*1000)triggerSwitchToBooking();
 }
 
 /* ========= セレクタ ========= */

--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -269,7 +269,8 @@ function checkAutoSwitch(now){
   const base=now instanceof Date?now:serverNow();
   const target=new Date(base.getTime());
   target.setHours(hh,mm,0,0);
-  if(base.getTime()>=target.getTime())triggerSwitchToBooking();
+  const diff=base.getTime()-target.getTime();
+  if(diff>=0&&diff<12*60*60*1000)triggerSwitchToBooking();
 }
 
 /* ========= セレクタ ========= */

--- a/expo2025-tm-autobooker-ios
+++ b/expo2025-tm-autobooker-ios
@@ -258,7 +258,8 @@ function checkAutoSwitch(now){
   const base=now instanceof Date?now:serverNow();
   const target=new Date(base.getTime());
   target.setHours(hh,mm,0,0);
-  if(base.getTime()>=target.getTime())triggerSwitchToBooking();
+  const diff=base.getTime()-target.getTime();
+  if(diff>=0&&diff<12*60*60*1000)triggerSwitchToBooking();
 }
 
 /* ========= セレクタ ========= */


### PR DESCRIPTION
## Summary
- avoid triggering the booking switch if the configured time is more than 12 hours in the past
- apply the same safeguard to the standard, iOS, and Android user scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7a2954508327a02924e7dc4a1d50