### PR TITLE
Fix keep-alive switch scheduling for next morning

### DIFF
--- a/expo2025-reserver-android.user.js
+++ b/expo2025-reserver-android.user.js
@@ -152,11 +152,12 @@ conf.times=normalizeTimeKeys(conf.times);
 Lset(CONF_KEY,conf);
 let stateRaw=Sget(STATE_KEY);
 if(typeof stateRaw!=='object'||!stateRaw){stateRaw={}};
-let state=Object.assign({r:false,keepAlive:false,switchEnabled:false,switchTime:''},stateRaw);
+let state=Object.assign({r:false,keepAlive:false,switchEnabled:false,switchTime:'',switchNextAt:0},stateRaw);
 if(typeof state.r!=='boolean')state.r=false;
 if(typeof state.keepAlive!=='boolean')state.keepAlive=false;
 if(typeof state.switchEnabled!=='boolean')state.switchEnabled=false;
 if(typeof state.switchTime!=='string')state.switchTime='';
+if(typeof state.switchNextAt!=='number'||!Number.isFinite(state.switchNextAt))state.switchNextAt=0;
 if(state.keepAlive&&state.r)state.r=false;
 Sset(STATE_KEY,state);
 function saveState(){Sset(STATE_KEY,state)}
@@ -273,7 +274,7 @@ function triggerSwitchToBooking(){
       updated=true;
     }
   }
-  if(!updated&&state.switchEnabled){state.switchEnabled=false;saveState()}
+  if(!updated&&state.switchEnabled){state.switchEnabled=false;state.switchNextAt=0;saveState()}
   if(KeepAliveToggleEl){
     if(KeepAliveToggleEl.checked){
       KeepAliveToggleEl.checked=false;
@@ -305,18 +306,32 @@ function triggerSwitchToBooking(){
 }
 function checkAutoSwitch(now){
   if(!state.keepAlive||!state.switchEnabled||keepAliveSwitching)return;
-  const t=state.switchTime;
-  if(!t||typeof t!=='string')return;
-  const m=t.match(/^(\d{1,2}):(\d{2})$/);
-  if(!m)return;
+  const parsed=parseSwitchTimeString(state.switchTime);
+  if(!parsed)return;
+  const base=now instanceof Date?now:serverNow();
+  if(!Number.isFinite(state.switchNextAt)||state.switchNextAt<=0){
+    state.switchNextAt=computeNextSwitchAt(base,parsed.hh,parsed.mm);
+    saveState();
+  }
+  if(base.getTime()>=state.switchNextAt)triggerSwitchToBooking();
+}
+
+function computeNextSwitchAt(base,hh,mm){
+  const ref=base instanceof Date?base:serverNow();
+  const target=new Date(ref.getTime());
+  target.setHours(hh,mm,0,0);
+  if(target.getTime()<ref.getTime())target.setDate(target.getDate()+1);
+  return target.getTime();
+}
+
+function parseSwitchTimeString(str){
+  if(typeof str!=='string'||!str)return null;
+  const m=str.match(/^(\d{1,2}):(\d{2})$/);
+  if(!m)return null;
   const hh=Number(m[1]);
   const mm=Number(m[2]);
-  if(Number.isNaN(hh)||Number.isNaN(mm))return;
-  const base=now instanceof Date?now:serverNow();
-  const target=new Date(base.getTime());
-  target.setHours(hh,mm,0,0);
-  const diff=base.getTime()-target.getTime();
-  if(diff>=0&&diff<12*60*60*1000)triggerSwitchToBooking();
+  if(Number.isNaN(hh)||Number.isNaN(mm))return null;
+  return {hh,mm};
 }
 
 /* ========= セレクタ ========= */
@@ -964,9 +979,9 @@ function renderChips(){chips.innerHTML='';conf.dates.forEach((ds,i)=>{const b=do
 renderChips();
 add.onclick=()=>{if(!din.value)return;const v=din.value;if(!conf.dates.includes(v))conf.dates.push(v);conf.dates.sort();Lset(CONF_KEY,conf);renderChips()};
   tg.addEventListener('change',()=>{if(tg.checked){if(conf.dates.length===0){stat.textContent='日付を追加してください';tg.checked=false;return}const activeTimeKeys=getActiveTimeKeys();if(activeTimeKeys.length===0){stat.textContent='時間帯を選択してください';lastStatusText=stat.textContent;tg.checked=false;return}if(state.keepAlive&&keepToggle.checked){keepToggle.checked=false;keepToggle.dispatchEvent(new Event('change',{bubbles:true}))}state.r=true;saveState();stat.textContent='稼働中';runCycle()}else{state.r=false;saveState();stat.textContent=state.keepAlive?keepAliveStatusText():'停止中';clearTimeout(Tm)}});
-keepToggle.addEventListener('change',()=>{if(keepToggle.checked){state.keepAlive=true;state.r=false;saveState();clearTimeout(Tm);if(tg.checked){tg.checked=false;tg.dispatchEvent(new Event('change',{bubbles:true}))}stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}else{state.keepAlive=false;if(state.switchEnabled){state.switchEnabled=false;if(switchCheck.checked)switchCheck.checked=false;}saveState();clearKeepAliveTimer();stat.textContent=state.r?'稼働中':'停止中';lastStatusText=stat.textContent;}});
-switchCheck.addEventListener('change',()=>{if(switchCheck.checked){if(!timeInput.value){stat.textContent='切替時刻を入力してください';lastStatusText=stat.textContent;switchCheck.checked=false;return}state.switchEnabled=true;state.switchTime=timeInput.value;saveState();if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}}else{if(state.switchEnabled){state.switchEnabled=false;saveState();}if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;}}});
-timeInput.addEventListener('change',()=>{const v=timeInput.value||'';state.switchTime=v;if(!v&&state.switchEnabled){state.switchEnabled=false;saveState();if(switchCheck.checked){switchCheck.checked=false;switchCheck.dispatchEvent(new Event('change',{bubbles:true}));return}}else{saveState()}if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;try{checkAutoSwitch(serverNow())}catch{}}});
+keepToggle.addEventListener('change',()=>{if(keepToggle.checked){state.keepAlive=true;state.r=false;saveState();clearTimeout(Tm);if(tg.checked){tg.checked=false;tg.dispatchEvent(new Event('change',{bubbles:true}))}stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}else{state.keepAlive=false;if(state.switchEnabled){state.switchEnabled=false;if(state.switchNextAt!==0)state.switchNextAt=0;if(switchCheck.checked)switchCheck.checked=false;}else if(state.switchNextAt!==0){state.switchNextAt=0;}saveState();clearKeepAliveTimer();stat.textContent=state.r?'稼働中':'停止中';lastStatusText=stat.textContent;}});
+switchCheck.addEventListener('change',()=>{if(switchCheck.checked){if(!timeInput.value){stat.textContent='切替時刻を入力してください';lastStatusText=stat.textContent;switchCheck.checked=false;return}state.switchEnabled=true;state.switchTime=timeInput.value;const parsed=parseSwitchTimeString(state.switchTime);if(parsed){state.switchNextAt=computeNextSwitchAt(serverNow(),parsed.hh,parsed.mm);}else{state.switchNextAt=0;}saveState();if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}}else{let changed=false;if(state.switchEnabled){state.switchEnabled=false;changed=true;}if(state.switchNextAt!==0){state.switchNextAt=0;changed=true;}if(changed)saveState();if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;}}});
+timeInput.addEventListener('change',()=>{const v=timeInput.value||'';state.switchTime=v;if(!v&&state.switchEnabled){state.switchEnabled=false;state.switchNextAt=0;saveState();if(switchCheck.checked){switchCheck.checked=false;switchCheck.dispatchEvent(new Event('change',{bubbles:true}));return}}else{if(state.switchEnabled&&v){const parsed=parseSwitchTimeString(v);if(parsed){state.switchNextAt=computeNextSwitchAt(serverNow(),parsed.hh,parsed.mm);}else{state.switchNextAt=0;}}else if(!state.switchEnabled&&state.switchNextAt!==0){state.switchNextAt=0;}saveState()}if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;try{checkAutoSwitch(serverNow())}catch{}}});
 function setStatus(x){if(lastStatusText!==x){lastStatusText=x;stat.textContent=x;}}
 function updateKeepAliveCountdown(){if(!state.keepAlive)return;const msg=keepAliveStatusText();if(lastStatusText!==msg){lastStatusText=msg;stat.textContent=msg;}}
 function uncheck(){try{tg.checked=false;tg.dispatchEvent(new Event('input',{bubbles:true}));tg.dispatchEvent(new Event('change',{bubbles:true}))}catch{}const txt=state.keepAlive?keepAliveStatusText():'停止中';stat.textContent=txt;lastStatusText=txt}

--- a/expo2025-reserver-ios.user.js
+++ b/expo2025-reserver-ios.user.js
@@ -141,11 +141,12 @@ conf.times=normalizeTimeKeys(conf.times);
 Lset(CONF_KEY,conf);
 let stateRaw=Sget(STATE_KEY);
 if(typeof stateRaw!=='object'||!stateRaw){stateRaw={}};
-let state=Object.assign({r:false,keepAlive:false,switchEnabled:false,switchTime:''},stateRaw);
+let state=Object.assign({r:false,keepAlive:false,switchEnabled:false,switchTime:'',switchNextAt:0},stateRaw);
 if(typeof state.r!=='boolean')state.r=false;
 if(typeof state.keepAlive!=='boolean')state.keepAlive=false;
 if(typeof state.switchEnabled!=='boolean')state.switchEnabled=false;
 if(typeof state.switchTime!=='string')state.switchTime='';
+if(typeof state.switchNextAt!=='number'||!Number.isFinite(state.switchNextAt))state.switchNextAt=0;
 if(state.keepAlive&&state.r)state.r=false;
 Sset(STATE_KEY,state);
 function saveState(){Sset(STATE_KEY,state)}
@@ -216,7 +217,7 @@ function triggerSwitchToBooking(){
       updated=true;
     }
   }
-  if(!updated&&state.switchEnabled){state.switchEnabled=false;saveState()}
+  if(!updated&&state.switchEnabled){state.switchEnabled=false;state.switchNextAt=0;saveState()}
   if(KeepAliveToggleEl){
     if(KeepAliveToggleEl.checked){
       KeepAliveToggleEl.checked=false;
@@ -248,18 +249,32 @@ function triggerSwitchToBooking(){
 }
 function checkAutoSwitch(now){
   if(!state.keepAlive||!state.switchEnabled||keepAliveSwitching)return;
-  const t=state.switchTime;
-  if(!t||typeof t!=='string')return;
-  const m=t.match(/^(\d{1,2}):(\d{2})$/);
-  if(!m)return;
+  const parsed=parseSwitchTimeString(state.switchTime);
+  if(!parsed)return;
+  const base=now instanceof Date?now:serverNow();
+  if(!Number.isFinite(state.switchNextAt)||state.switchNextAt<=0){
+    state.switchNextAt=computeNextSwitchAt(base,parsed.hh,parsed.mm);
+    saveState();
+  }
+  if(base.getTime()>=state.switchNextAt)triggerSwitchToBooking();
+}
+
+function computeNextSwitchAt(base,hh,mm){
+  const ref=base instanceof Date?base:serverNow();
+  const target=new Date(ref.getTime());
+  target.setHours(hh,mm,0,0);
+  if(target.getTime()<ref.getTime())target.setDate(target.getDate()+1);
+  return target.getTime();
+}
+
+function parseSwitchTimeString(str){
+  if(typeof str!=='string'||!str)return null;
+  const m=str.match(/^(\d{1,2}):(\d{2})$/);
+  if(!m)return null;
   const hh=Number(m[1]);
   const mm=Number(m[2]);
-  if(Number.isNaN(hh)||Number.isNaN(mm))return;
-  const base=now instanceof Date?now:serverNow();
-  const target=new Date(base.getTime());
-  target.setHours(hh,mm,0,0);
-  const diff=base.getTime()-target.getTime();
-  if(diff>=0&&diff<12*60*60*1000)triggerSwitchToBooking();
+  if(Number.isNaN(hh)||Number.isNaN(mm))return null;
+  return {hh,mm};
 }
 
 /* ========= セレクタ ========= */
@@ -905,9 +920,9 @@ function renderChips(){chips.innerHTML='';conf.dates.forEach((ds,i)=>{const b=do
 renderChips();
 add.onclick=()=>{if(!din.value)return;const v=din.value;if(!conf.dates.includes(v))conf.dates.push(v);conf.dates.sort();Lset(CONF_KEY,conf);renderChips()};
   tg.addEventListener('change',()=>{if(tg.checked){if(conf.dates.length===0){stat.textContent='日付を追加してください';tg.checked=false;return}const activeTimeKeys=getActiveTimeKeys();if(activeTimeKeys.length===0){stat.textContent='時間帯を選択してください';lastStatusText=stat.textContent;tg.checked=false;return}if(state.keepAlive&&keepToggle.checked){keepToggle.checked=false;keepToggle.dispatchEvent(new Event('change',{bubbles:true}))}state.r=true;saveState();stat.textContent='稼働中';runCycle()}else{state.r=false;saveState();stat.textContent=state.keepAlive?keepAliveStatusText():'停止中';clearTimeout(Tm)}});
-keepToggle.addEventListener('change',()=>{if(keepToggle.checked){state.keepAlive=true;state.r=false;saveState();clearTimeout(Tm);if(tg.checked){tg.checked=false;tg.dispatchEvent(new Event('change',{bubbles:true}))}stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}else{state.keepAlive=false;if(state.switchEnabled){state.switchEnabled=false;if(switchCheck.checked)switchCheck.checked=false;}saveState();clearKeepAliveTimer();stat.textContent=state.r?'稼働中':'停止中';lastStatusText=stat.textContent;}});
-switchCheck.addEventListener('change',()=>{if(switchCheck.checked){if(!timeInput.value){stat.textContent='切替時刻を入力してください';lastStatusText=stat.textContent;switchCheck.checked=false;return}state.switchEnabled=true;state.switchTime=timeInput.value;saveState();if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}}else{if(state.switchEnabled){state.switchEnabled=false;saveState();}if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;}}});
-timeInput.addEventListener('change',()=>{const v=timeInput.value||'';state.switchTime=v;if(!v&&state.switchEnabled){state.switchEnabled=false;saveState();if(switchCheck.checked){switchCheck.checked=false;switchCheck.dispatchEvent(new Event('change',{bubbles:true}));return}}else{saveState()}if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;try{checkAutoSwitch(serverNow())}catch{}}});
+keepToggle.addEventListener('change',()=>{if(keepToggle.checked){state.keepAlive=true;state.r=false;saveState();clearTimeout(Tm);if(tg.checked){tg.checked=false;tg.dispatchEvent(new Event('change',{bubbles:true}))}stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}else{state.keepAlive=false;if(state.switchEnabled){state.switchEnabled=false;if(state.switchNextAt!==0)state.switchNextAt=0;if(switchCheck.checked)switchCheck.checked=false;}else if(state.switchNextAt!==0){state.switchNextAt=0;}saveState();clearKeepAliveTimer();stat.textContent=state.r?'稼働中':'停止中';lastStatusText=stat.textContent;}});
+switchCheck.addEventListener('change',()=>{if(switchCheck.checked){if(!timeInput.value){stat.textContent='切替時刻を入力してください';lastStatusText=stat.textContent;switchCheck.checked=false;return}state.switchEnabled=true;state.switchTime=timeInput.value;const parsed=parseSwitchTimeString(state.switchTime);if(parsed){state.switchNextAt=computeNextSwitchAt(serverNow(),parsed.hh,parsed.mm);}else{state.switchNextAt=0;}saveState();if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;scheduleKeepAliveReload();try{checkAutoSwitch(serverNow())}catch{}}}else{let changed=false;if(state.switchEnabled){state.switchEnabled=false;changed=true;}if(state.switchNextAt!==0){state.switchNextAt=0;changed=true;}if(changed)saveState();if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;}}});
+timeInput.addEventListener('change',()=>{const v=timeInput.value||'';state.switchTime=v;if(!v&&state.switchEnabled){state.switchEnabled=false;state.switchNextAt=0;saveState();if(switchCheck.checked){switchCheck.checked=false;switchCheck.dispatchEvent(new Event('change',{bubbles:true}));return}}else{if(state.switchEnabled&&v){const parsed=parseSwitchTimeString(v);if(parsed){state.switchNextAt=computeNextSwitchAt(serverNow(),parsed.hh,parsed.mm);}else{state.switchNextAt=0;}}else if(!state.switchEnabled&&state.switchNextAt!==0){state.switchNextAt=0;}saveState()}if(state.keepAlive){stat.textContent=keepAliveStatusText();lastStatusText=stat.textContent;try{checkAutoSwitch(serverNow())}catch{}}});
 function setStatus(x){if(lastStatusText!==x){lastStatusText=x;stat.textContent=x;}}
 function updateKeepAliveCountdown(){if(!state.keepAlive)return;const msg=keepAliveStatusText();if(lastStatusText!==msg){lastStatusText=msg;stat.textContent=msg;}}
 function uncheck(){try{tg.checked=false;tg.dispatchEvent(new Event('input',{bubbles:true}));tg.dispatchEvent(new Event('change',{bubbles:true}))}catch{}const txt=state.keepAlive?keepAliveStatusText():'停止中';stat.textContent=txt;lastStatusText=txt}


### PR DESCRIPTION
## Summary
- persist the next switch timestamp so morning times schedule for the following day instead of triggering immediately
- recompute or clear the stored schedule when toggles change to keep the login keep-alive checkbox from being cleared unexpectedly
- apply the same logic across the web, iOS, and Android user scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbaf44a9708327adbda1bf160ceff3