### PR TITLE
Fix next-day switch scheduling for keep-alive mode

### DIFF
--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -256,7 +256,7 @@ function computeNextSwitchAt(base,hh,mm){
   const ref=base instanceof Date?base:serverNow();
   const target=new Date(ref.getTime());
   target.setHours(hh,mm,0,0);
-  if(target.getTime()<ref.getTime())target.setDate(target.getDate()+1);
+  if(target.getTime()<=ref.getTime())target.setDate(target.getDate()+1);
   return target.getTime();
 }
 function parseSwitchTimeString(str){
@@ -277,7 +277,16 @@ function checkAutoSwitch(now){
     state.switchNextAt=computeNextSwitchAt(base,parsed.hh,parsed.mm);
     saveState();
   }
-  if(base.getTime()>=state.switchNextAt)triggerSwitchToBooking();
+  if(base.getTime()>=state.switchNextAt){
+    if(base.getTime()>state.switchNextAt){
+      const recalculated=computeNextSwitchAt(base,parsed.hh,parsed.mm);
+      if(recalculated!==state.switchNextAt){
+        state.switchNextAt=recalculated;
+        saveState();
+      }
+    }
+    if(base.getTime()>=state.switchNextAt)triggerSwitchToBooking();
+  }
 }
 
 /* ========= セレクタ ========= */


### PR DESCRIPTION
## Summary
- ensure the scheduled switch time rolls over to the next day when the entered time has already passed
- recalculate stale switch timestamps so the login keep-alive checkbox is not toggled unexpectedly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbb345c8a0832791f650237dc6672d