### PR TITLE
Add change test userscript ensuring time reselection

### DIFF
--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
-// @name         Expo2025 来場予約
+// @name         Expo2025 予約変更
 // @namespace    http://tampermonkey.net/
-// @version      2.72
+// @version      1.0
 // @author       You
 // @match        https://ticket.expo2025.or.jp/*
 // @run-at       document-idle
 // @grant        none
-// @updateURL    https://github.com/expo2025-auto/expo2025-tm-autobooker/raw/refs/heads/main/expo2025-reserver.user.js
-// @downloadURL  https://github.com/expo2025-auto/expo2025-tm-autobooker/raw/refs/heads/main/expo2025-reserver.user.js
+// @updateURL    https://github.com/expo2025-auto/expo2025-tm-autobooker/raw/refs/heads/main/expo2025-reserver-change-test.user.js
+// @downloadURL  https://github.com/expo2025-auto/expo2025-tm-autobooker/raw/refs/heads/main/expo2025-reserver-change-test.user.js
 // @supportURL   https://github.com/expo2025-auto/expo2025-tm-autobooker/issues
 // ==/UserScript==
 


### PR DESCRIPTION
## Summary
- duplicate the regular userscript into a change-verification variant
- add helpers that read and enforce the intended time slot selection before confirming
- update the confirmation flow to revalidate the chosen date/time so earlier slots are reliably applied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc9576f4a08327966409a63b2c8ce4