### PR TITLE
Reload immediately on fail toast detection

### DIFF
--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -326,7 +326,7 @@ function hasFailToast(){
 }
 ;(function armFastFailReload(){
   let armed=false;
-  const kick=()=>{if(armed)return;armed=true;setTimeout(()=>{if(hasFailToast())robustReload()},500)};
+  const kick=()=>{if(armed)return;armed=true;robustReload()};
   const mo=new MutationObserver(muts=>{
     for(const m of muts){
       if(m.type==='childList'){


### PR DESCRIPTION
## Summary
- trigger the fail-toast reload logic immediately instead of waiting 500ms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcb543c1888327bf84288f80862370