### PR TITLE
Ensure runCycle only reacts to visible result modals

### DIFF
--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -1061,8 +1061,10 @@ function stopOK(msg){try{clearTimeout(Tm)}catch{}state.r=false;saveState();ui.un
 
 async function runCycle(){
   if(isTypeSelectionPage()){resetFail();ui.setStatus('券種選択ページに移動しました');return}
-  if(Q(SEL_SUCC)){resetFail();stopOK();return}
-  if(Q(SEL_FAIL)){return}
+  const succModal=Q(SEL_SUCC);
+  if(succModal&&isShown(succModal)){resetFail();stopOK();return}
+  const failModal=Q(SEL_FAIL);
+  if(failModal&&isShown(failModal)){return}
   if(!state.r)return;
   if(state.keepAlive){ui.setStatus(keepAliveStatusText());return;}
 


### PR DESCRIPTION
## Summary
- ensure runCycle only handles success and failure modals when they are visible

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dd02280f2483279eb56b93658e28c7