### PR TITLE
Ensure change test script only reacts to visible modals

### DIFF
--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -1383,8 +1383,10 @@ function stopOK(msg){try{clearTimeout(Tm)}catch{}state.r=false;resetQuickRetryTr
 
 async function runCycle(){
   if(isTypeSelectionPage()){resetFail();ui.setStatus('券種選択ページに移動しました');return}
-  if(Q(SEL_SUCC)){resetFail();stopOK();return}
-  if(Q(SEL_FAIL)){return}
+  const succModal=Q(SEL_SUCC);
+  if(succModal&&isShown(succModal)){resetFail();stopOK();return}
+  const failModal=Q(SEL_FAIL);
+  if(failModal&&isShown(failModal)){return}
   if(!state.r){setAttemptReservationDisplay(null);return;}
   if(state.keepAlive){setAttemptReservationDisplay(null);ui.setStatus(keepAliveStatusText());return;}
   setAttemptReservationDisplay(null);

--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -1061,8 +1061,10 @@ function stopOK(msg){try{clearTimeout(Tm)}catch{}state.r=false;saveState();ui.un
 
 async function runCycle(){
   if(isTypeSelectionPage()){resetFail();ui.setStatus('券種選択ページに移動しました');return}
-  if(Q(SEL_SUCC)){resetFail();stopOK();return}
-  if(Q(SEL_FAIL)){return}
+  const succModal=Q(SEL_SUCC);
+  if(succModal&&isShown(succModal)){resetFail();stopOK();return}
+  const failModal=Q(SEL_FAIL);
+  if(failModal&&isShown(failModal)){return}
   if(!state.r)return;
   if(state.keepAlive){ui.setStatus(keepAliveStatusText());return;}
 


### PR DESCRIPTION
## Summary
- ensure runCycle in change test script only handles success and failure modals when they are visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd02280f2483279eb56b93658e28c7