### PR TITLE
Ensure change flow prefers set-date button

### DIFF
--- a/expo2025-reserver-android.user.js
+++ b/expo2025-reserver-android.user.js
@@ -888,19 +888,32 @@ async function flowConfirm(targetISO,{targetTimeKey,allowedTimeKeys}={}){
     return null;
   };
   const findConfirmBtn=(exclude=new Set())=>{
-    for(const sel of confirmBtnSelectors){
-      const candidates=A(sel);
-      if(!candidates.length)continue;
-      for(const el of candidates){
-        if(exclude.has(el))continue;
-        if(isEnabled(el)&&vis(el))return el;
+    const scoreEl=el=>{
+      if(matchesSetDateText(el))return 0;
+      if(matchesConfirmText(el))return 1;
+      return 2;
+    };
+    const seen=new Set();
+    const collect=(arr)=>{
+      const result=[];
+      for(const el of arr){
+        if(!el||exclude.has(el)||seen.has(el))continue;
+        seen.add(el);
+        if(!isEnabled(el)||!vis(el))continue;
+        result.push(el);
       }
+      return result;
+    };
+    for(const sel of confirmBtnSelectors){
+      const list=collect(A(sel));
+      if(!list.length)continue;
+      list.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(list[0])return list[0];
     }
-    const candidates=A('button, [role="button"], a');
-    for(const el of candidates){
-      if(exclude.has(el))continue;
-      if(!isEnabled(el)||!vis(el))continue;
-      if(matchesConfirmText(el))return el;
+    const fallback=collect(A('button, [role="button"], a'));
+    if(fallback.length){
+      fallback.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(fallback[0])return fallback[0];
     }
     return null;
   };

--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -888,19 +888,32 @@ async function flowConfirm(targetISO,{targetTimeKey,allowedTimeKeys}={}){
     return null;
   };
   const findConfirmBtn=(exclude=new Set())=>{
-    for(const sel of confirmBtnSelectors){
-      const candidates=A(sel);
-      if(!candidates.length)continue;
-      for(const el of candidates){
-        if(exclude.has(el))continue;
-        if(isEnabled(el)&&vis(el))return el;
+    const scoreEl=el=>{
+      if(matchesSetDateText(el))return 0;
+      if(matchesConfirmText(el))return 1;
+      return 2;
+    };
+    const seen=new Set();
+    const collect=(arr)=>{
+      const result=[];
+      for(const el of arr){
+        if(!el||exclude.has(el)||seen.has(el))continue;
+        seen.add(el);
+        if(!isEnabled(el)||!vis(el))continue;
+        result.push(el);
       }
+      return result;
+    };
+    for(const sel of confirmBtnSelectors){
+      const list=collect(A(sel));
+      if(!list.length)continue;
+      list.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(list[0])return list[0];
     }
-    const candidates=A('button, [role="button"], a');
-    for(const el of candidates){
-      if(exclude.has(el))continue;
-      if(!isEnabled(el)||!vis(el))continue;
-      if(matchesConfirmText(el))return el;
+    const fallback=collect(A('button, [role="button"], a'));
+    if(fallback.length){
+      fallback.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(fallback[0])return fallback[0];
     }
     return null;
   };

--- a/expo2025-reserver-ios.user.js
+++ b/expo2025-reserver-ios.user.js
@@ -874,19 +874,32 @@ async function flowConfirm(targetISO,{targetTimeKey,allowedTimeKeys}={}){
     return null;
   };
   const findConfirmBtn=(exclude=new Set())=>{
-    for(const sel of confirmBtnSelectors){
-      const candidates=A(sel);
-      if(!candidates.length)continue;
-      for(const el of candidates){
-        if(exclude.has(el))continue;
-        if(isEnabled(el)&&vis(el))return el;
+    const scoreEl=el=>{
+      if(matchesSetDateText(el))return 0;
+      if(matchesConfirmText(el))return 1;
+      return 2;
+    };
+    const seen=new Set();
+    const collect=(arr)=>{
+      const result=[];
+      for(const el of arr){
+        if(!el||exclude.has(el)||seen.has(el))continue;
+        seen.add(el);
+        if(!isEnabled(el)||!vis(el))continue;
+        result.push(el);
       }
+      return result;
+    };
+    for(const sel of confirmBtnSelectors){
+      const list=collect(A(sel));
+      if(!list.length)continue;
+      list.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(list[0])return list[0];
     }
-    const candidates=A('button, [role="button"], a');
-    for(const el of candidates){
-      if(exclude.has(el))continue;
-      if(!isEnabled(el)||!vis(el))continue;
-      if(matchesConfirmText(el))return el;
+    const fallback=collect(A('button, [role="button"], a'));
+    if(fallback.length){
+      fallback.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(fallback[0])return fallback[0];
     }
     return null;
   };

--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -888,19 +888,32 @@ async function flowConfirm(targetISO,{targetTimeKey,allowedTimeKeys}={}){
     return null;
   };
   const findConfirmBtn=(exclude=new Set())=>{
-    for(const sel of confirmBtnSelectors){
-      const candidates=A(sel);
-      if(!candidates.length)continue;
-      for(const el of candidates){
-        if(exclude.has(el))continue;
-        if(isEnabled(el)&&vis(el))return el;
+    const scoreEl=el=>{
+      if(matchesSetDateText(el))return 0;
+      if(matchesConfirmText(el))return 1;
+      return 2;
+    };
+    const seen=new Set();
+    const collect=(arr)=>{
+      const result=[];
+      for(const el of arr){
+        if(!el||exclude.has(el)||seen.has(el))continue;
+        seen.add(el);
+        if(!isEnabled(el)||!vis(el))continue;
+        result.push(el);
       }
+      return result;
+    };
+    for(const sel of confirmBtnSelectors){
+      const list=collect(A(sel));
+      if(!list.length)continue;
+      list.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(list[0])return list[0];
     }
-    const candidates=A('button, [role="button"], a');
-    for(const el of candidates){
-      if(exclude.has(el))continue;
-      if(!isEnabled(el)||!vis(el))continue;
-      if(matchesConfirmText(el))return el;
+    const fallback=collect(A('button, [role="button"], a'));
+    if(fallback.length){
+      fallback.sort((a,b)=>scoreEl(a)-scoreEl(b));
+      if(fallback[0])return fallback[0];
     }
     return null;
   };


### PR DESCRIPTION
## 目的 / Purpose
- Ensure the automation reliably presses the "来場日時を設定する" confirmation button during reservation changes.

## 変更点 / Changes
- Prioritize visible confirmation buttons that match the set-date text hints across the desktop, Android, iOS, and change-test scripts so the correct control is chosen when multiple buttons are present.

## テスト / Test
- [ ] ローカルで Tampermonkey にインストールして動作確認
- [ ] main ページ / 予約ページの描画遅延に対する耐性確認
- [ ] 10月ページ送り（nextMonth）確認

## メモ / Notes


------
https://chatgpt.com/codex/tasks/task_e_68dd2a05c07483279f31708ed943fc2c