### PR TITLE
Adjust minute reload window to 25 seconds

### DIFF
--- a/Legacy-expo2025-ios.user.js
+++ b/Legacy-expo2025-ios.user.js
@@ -599,17 +599,17 @@ let serverOffset=0;
 async function syncServer(){try{const res=await fetch(location.origin+'/',{method:'HEAD',cache:'no-store'});const dh=res.headers.get('date');if(dh){const sv=new Date(dh).getTime();serverOffset=sv-Date.now()}}catch{}}
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_11s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(11,0);if(n.getSeconds()>11||(n.getSeconds()===11&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 function scheduleRetryOrNextMinute(){
   const sec=secondsInMinute();
-  if(sec<23){
+  if(sec<37){
     if(state.r){
-      ui.setStatus('即再読込（<23s）');
+      ui.setStatus('即再読込（<37s）');
       safeReload();
     }
   }else{
-    const d=delayUntilNextMinute_11s();
-    ui.setStatus('次: →11s (+'+(Math.round(d/100)/10)+'s)');
+    const d=delayUntilNextMinute_25s();
+    ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
   }
@@ -823,17 +823,17 @@ async function runCycle(){
 
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
-  if(sec<11){
-    const d=delayUntilNextMinute_11s();
-    ui.setStatus('待機: →11s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec<25){
+    const d=delayUntilNextMinute_25s();
+    ui.setStatus('待機: →25s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
   }
 
-  if(sec>=23){
-    const d=delayUntilNextMinute_11s();
-    ui.setStatus('枠外: →11s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec>=37){
+    const d=delayUntilNextMinute_25s();
+    ui.setStatus('枠外: →25s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
@@ -875,8 +875,8 @@ async function runCycle(){
     if(r==='ng'){ui.setStatus('押し負け→継続');break}
   }
 
-  const d=delayUntilNextMinute_11s();
-  ui.setStatus('次: →11s (+'+(Math.round(d/100)/10)+'s)');
+  const d=delayUntilNextMinute_25s();
+  ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
 }

--- a/Legacy-expo2025-ios.user.js
+++ b/Legacy-expo2025-ios.user.js
@@ -599,17 +599,17 @@ let serverOffset=0;
 async function syncServer(){try{const res=await fetch(location.origin+'/',{method:'HEAD',cache:'no-store'});const dh=res.headers.get('date');if(dh){const sv=new Date(dh).getTime();serverOffset=sv-Date.now()}}catch{}}
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_15s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(15,0);if(n.getSeconds()>15||(n.getSeconds()===15&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 function scheduleRetryOrNextMinute(){
   const sec=secondsInMinute();
-  if(sec<37){
+  if(sec<25){
     if(state.r){
-      ui.setStatus('即再読込（<37s）');
+      ui.setStatus('即再読込（<25s）');
       safeReload();
     }
   }else{
-    const d=delayUntilNextMinute_25s();
-    ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
+    const d=delayUntilNextMinute_15s();
+    ui.setStatus('次: →15s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
   }
@@ -823,17 +823,17 @@ async function runCycle(){
 
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
-  if(sec<25){
-    const d=delayUntilNextMinute_25s();
-    ui.setStatus('待機: →25s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec<15){
+    const d=delayUntilNextMinute_15s();
+    ui.setStatus('待機: →15s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
   }
 
-  if(sec>=37){
-    const d=delayUntilNextMinute_25s();
-    ui.setStatus('枠外: →25s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec>=25){
+    const d=delayUntilNextMinute_15s();
+    ui.setStatus('枠外: →15s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
@@ -875,8 +875,8 @@ async function runCycle(){
     if(r==='ng'){ui.setStatus('押し負け→継続');break}
   }
 
-  const d=delayUntilNextMinute_25s();
-  ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
+  const d=delayUntilNextMinute_15s();
+  ui.setStatus('次: →15s (+'+(Math.round(d/100)/10)+'s)');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
 }

--- a/Legacy-expo2025.js
+++ b/Legacy-expo2025.js
@@ -2,7 +2,7 @@
 // @name         (旧) Expo2025 予約オート
 // @namespace    http://tampermonkey.net/
 // @version      1.1.2
-// @description  可視/活性監視→即クリック。毎分25秒に開始、選択不可は37秒まで即リロードで粘る。失敗時は保険の強制リロード（最大3回）。UI：複数日/サーバ時刻表示/日付ロック/有効化待ち対応。タブごとにON/OFF独立。デフォルトOFF。10月指定時は必要に応じて次月ページめくり（JSパス優先 & ハードクリック）。
+// @description  可視/活性監視→即クリック。毎分15秒に開始、選択不可は25秒まで即リロードで粘る。失敗時は保険の強制リロード（最大3回）。UI：複数日/サーバ時刻表示/日付ロック/有効化待ち対応。タブごとにON/OFF独立。デフォルトOFF。10月指定時は必要に応じて次月ページめくり（JSパス優先 & ハードクリック）。
 // @author       You
 // @match        https://ticket.expo2025.or.jp/*
 // @run-at       document-idle
@@ -602,17 +602,17 @@ let serverOffset=0;
 async function syncServer(){try{const res=await fetch(location.origin+'/',{method:'HEAD',cache:'no-store'});const dh=res.headers.get('date');if(dh){const sv=new Date(dh).getTime();serverOffset=sv-Date.now()}}catch{}}
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_15s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(15,0);if(n.getSeconds()>15||(n.getSeconds()===15&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 function scheduleRetryOrNextMinute(){
   const sec=secondsInMinute();
-  if(sec<37){
+  if(sec<25){
     if(state.r){
-      ui.setStatus('即再読込（<37s）');
+      ui.setStatus('即再読込（<25s）');
       safeReload();
     }
   }else{
-    const d=delayUntilNextMinute_25s();
-    ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
+    const d=delayUntilNextMinute_15s();
+    ui.setStatus('次: →15s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
   }
@@ -826,17 +826,17 @@ async function runCycle(){
 
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
-  if(sec<25){
-    const d=delayUntilNextMinute_25s();
-    ui.setStatus('待機: →25s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec<15){
+    const d=delayUntilNextMinute_15s();
+    ui.setStatus('待機: →15s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
   }
 
-  if(sec>=37){
-    const d=delayUntilNextMinute_25s();
-    ui.setStatus('枠外: →25s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec>=25){
+    const d=delayUntilNextMinute_15s();
+    ui.setStatus('枠外: →15s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
@@ -878,8 +878,8 @@ async function runCycle(){
     if(r==='ng'){ui.setStatus('押し負け→継続');break}
   }
 
-  const d=delayUntilNextMinute_25s();
-  ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
+  const d=delayUntilNextMinute_15s();
+  ui.setStatus('次: →15s (+'+(Math.round(d/100)/10)+'s)');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
 }

--- a/Legacy-expo2025.js
+++ b/Legacy-expo2025.js
@@ -2,7 +2,7 @@
 // @name         (旧) Expo2025 予約オート
 // @namespace    http://tampermonkey.net/
 // @version      1.1.2
-// @description  可視/活性監視→即クリック。毎分11秒に開始、選択不可は23秒まで即リロードで粘る。失敗時は保険の強制リロード（最大3回）。UI：複数日/サーバ時刻表示/日付ロック/有効化待ち対応。タブごとにON/OFF独立。デフォルトOFF。10月指定時は必要に応じて次月ページめくり（JSパス優先 & ハードクリック）。
+// @description  可視/活性監視→即クリック。毎分25秒に開始、選択不可は37秒まで即リロードで粘る。失敗時は保険の強制リロード（最大3回）。UI：複数日/サーバ時刻表示/日付ロック/有効化待ち対応。タブごとにON/OFF独立。デフォルトOFF。10月指定時は必要に応じて次月ページめくり（JSパス優先 & ハードクリック）。
 // @author       You
 // @match        https://ticket.expo2025.or.jp/*
 // @run-at       document-idle
@@ -602,17 +602,17 @@ let serverOffset=0;
 async function syncServer(){try{const res=await fetch(location.origin+'/',{method:'HEAD',cache:'no-store'});const dh=res.headers.get('date');if(dh){const sv=new Date(dh).getTime();serverOffset=sv-Date.now()}}catch{}}
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_11s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(11,0);if(n.getSeconds()>11||(n.getSeconds()===11&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 function scheduleRetryOrNextMinute(){
   const sec=secondsInMinute();
-  if(sec<23){
+  if(sec<37){
     if(state.r){
-      ui.setStatus('即再読込（<23s）');
+      ui.setStatus('即再読込（<37s）');
       safeReload();
     }
   }else{
-    const d=delayUntilNextMinute_11s();
-    ui.setStatus('次: →11s (+'+(Math.round(d/100)/10)+'s)');
+    const d=delayUntilNextMinute_25s();
+    ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
   }
@@ -826,17 +826,17 @@ async function runCycle(){
 
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
-  if(sec<11){
-    const d=delayUntilNextMinute_11s();
-    ui.setStatus('待機: →11s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec<25){
+    const d=delayUntilNextMinute_25s();
+    ui.setStatus('待機: →25s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
   }
 
-  if(sec>=23){
-    const d=delayUntilNextMinute_11s();
-    ui.setStatus('枠外: →11s (+'+(Math.round(d/100)/10)+'s)');
+  if(sec>=37){
+    const d=delayUntilNextMinute_25s();
+    ui.setStatus('枠外: →25s (+'+(Math.round(d/100)/10)+'s)');
     clearTimeout(Tm);
     Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
     return;
@@ -878,8 +878,8 @@ async function runCycle(){
     if(r==='ng'){ui.setStatus('押し負け→継続');break}
   }
 
-  const d=delayUntilNextMinute_11s();
-  ui.setStatus('次: →11s (+'+(Math.round(d/100)/10)+'s)');
+  const d=delayUntilNextMinute_25s();
+  ui.setStatus('次: →25s (+'+(Math.round(d/100)/10)+'s)');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();safeReload()}},d);
 }

--- a/expo2025-reserver-android.user.js
+++ b/expo2025-reserver-android.user.js
@@ -1240,7 +1240,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_15s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(15,0);if(n.getSeconds()>15||(n.getSeconds()===15&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1256,14 +1256,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<37&&forcedState.count<3){
+  if(sec<25&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1430,18 +1430,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<25){
+    if(sec<15){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=37){
+    if(sec>=25){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1490,7 +1490,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver-android.user.js
+++ b/expo2025-reserver-android.user.js
@@ -1240,7 +1240,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_11s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(11,0);if(n.getSeconds()>11||(n.getSeconds()===11&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1256,14 +1256,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<23&&forcedState.count<3){
+  if(sec<37&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1430,18 +1430,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<11){
+    if(sec<25){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=23){
+    if(sec>=37){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1490,7 +1490,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -1232,7 +1232,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_15s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(15,0);if(n.getSeconds()>15||(n.getSeconds()===15&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1248,14 +1248,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<37&&forcedState.count<3){
+  if(sec<25&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1422,18 +1422,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<25){
+    if(sec<15){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=37){
+    if(sec>=25){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1482,7 +1482,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -1232,7 +1232,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_11s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(11,0);if(n.getSeconds()>11||(n.getSeconds()===11&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1248,14 +1248,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<23&&forcedState.count<3){
+  if(sec<37&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1422,18 +1422,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<11){
+    if(sec<25){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=23){
+    if(sec>=37){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1482,7 +1482,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver-ios.user.js
+++ b/expo2025-reserver-ios.user.js
@@ -1209,7 +1209,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_15s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(15,0);if(n.getSeconds()>15||(n.getSeconds()===15&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1225,14 +1225,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<37&&forcedState.count<3){
+  if(sec<25&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1399,18 +1399,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<25){
+    if(sec<15){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=37){
+    if(sec>=25){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1459,7 +1459,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver-ios.user.js
+++ b/expo2025-reserver-ios.user.js
@@ -1209,7 +1209,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_11s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(11,0);if(n.getSeconds()>11||(n.getSeconds()===11&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1225,14 +1225,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<23&&forcedState.count<3){
+  if(sec<37&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1399,18 +1399,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<11){
+    if(sec<25){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=23){
+    if(sec>=37){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1459,7 +1459,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -1240,7 +1240,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_15s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(15,0);if(n.getSeconds()>15||(n.getSeconds()===15&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1256,14 +1256,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<37&&forcedState.count<3){
+  if(sec<25&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1430,18 +1430,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<25){
+    if(sec<15){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=37){
+    if(sec>=25){
       resetForcedReload();
-      const d=delayUntilNextMinute_25s();
+      const d=delayUntilNextMinute_15s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1490,7 +1490,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_25s();
+  const d=delayUntilNextMinute_15s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);

--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -1240,7 +1240,7 @@ async function syncServer({force=false}={}){
 }
 function serverNow(){return new Date(Date.now()+serverOffset)}
 function secondsInMinute(){const n=serverNow();return n.getSeconds()+n.getMilliseconds()/1000}
-function delayUntilNextMinute_11s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(11,0);if(n.getSeconds()>11||(n.getSeconds()===11&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
+function delayUntilNextMinute_25s(){const n=serverNow(),nx=new Date(n.getTime());nx.setSeconds(25,0);if(n.getSeconds()>25||(n.getSeconds()===25&&n.getMilliseconds()>0))nx.setMinutes(nx.getMinutes()+1);return nx.getTime()-n.getTime()}
 const FORCED_RELOAD_KEY='nr_forced_reload_v1';
 function minuteBucket(now){const t=now instanceof Date?now.getTime():Number(now);if(!Number.isFinite(t))return 0;return Math.floor(t/60000)}
 function readForcedReloadState(){try{const raw=sessionStorage.getItem(FORCED_RELOAD_KEY);if(!raw)return{minute:0,count:0};const parsed=JSON.parse(raw);const minute=Number(parsed?.minute);const count=Number(parsed?.count);return{minute:Number.isFinite(minute)?minute:0,count:Number.isFinite(count)?count:0}}catch{return{minute:0,count:0}}}
@@ -1256,14 +1256,14 @@ function scheduleRetryOrNextMinute(){
   const now=serverNow();
   const sec=now.getSeconds()+now.getMilliseconds()/1000;
   const forcedState=getForcedReloadState(now);
-  if(sec<23&&forcedState.count<3){
+  if(sec<37&&forcedState.count<3){
     ui.setStatus('再試行中');
     clearTimeout(Tm);
     incrementForcedReload(now);
     safeReload();
     return;
   }
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1430,18 +1430,18 @@ async function runCycle(){
   await syncServer().catch(()=>{});
   const sec=secondsInMinute();
   if(!forceScanActive){
-    if(sec<11){
+    if(sec<25){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('待機中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
       return;
     }
 
-    if(sec>=23){
+    if(sec>=37){
       resetForcedReload();
-      const d=delayUntilNextMinute_11s();
+      const d=delayUntilNextMinute_25s();
       ui.setStatus('再試行中');
       clearTimeout(Tm);
       Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);
@@ -1490,7 +1490,7 @@ async function runCycle(){
   }
 
   resetForcedReload();
-  const d=delayUntilNextMinute_11s();
+  const d=delayUntilNextMinute_25s();
   ui.setStatus('待機中');
   clearTimeout(Tm);
   Tm=setTimeout(()=>{if(state.r){resetFail();resetForcedReload();safeReload()}},d);


### PR DESCRIPTION
## Summary
- retime the minute-based reload in all Expo2025 reserver variants to trigger at the 25-second mark and extend the retry window to 37 seconds
- refresh legacy script messaging to reflect the new 25-second start and 37-second retry window

## Testing
- not run (Tampermonkey userscripts)


------
https://chatgpt.com/codex/tasks/task_e_68dde566752883279c7aa464d7687fb6