### PR TITLE
Handle toast change button in legacy confirm flow

### DIFF
--- a/Legacy-expo2025.js
+++ b/Legacy-expo2025.js
@@ -375,16 +375,82 @@ async function waitEnabled(selOrEl,timeout=10000){
 }
 async function flowConfirm(targetISO){
   if(selectedDateISO()!==targetISO)return false;
+  const clickedButtons=new Set();
   const host='#__next > div > div > main > div > div.style_main__add_cart_button__DCOw8';
   const primarySel=host+' .basic-btn.type2.style_full__ptzZq';
   let b=await waitEnabled(primarySel,12000)||await waitEnabled('button.basic-btn.type2.style_full__ptzZq',12000);
   if(!b||selectedDateISO()!==targetISO)return false;
+  const normalizedTextOf=el=>{
+    if(!el)return'';
+    const values=[];
+    if(el.textContent)values.push(el.textContent);
+    if(el.innerText&&el.innerText!==el.textContent)values.push(el.innerText);
+    if(el.getAttribute){
+      values.push(el.getAttribute('aria-label')||'');
+      values.push(el.getAttribute('title')||'');
+    }
+    return values.filter(Boolean).map(v=>String(v).replace(/\s+/g,'')).join('');
+  };
+  const matchesHints=(el,hints)=>{
+    if(!Array.isArray(hints)||!hints.length)return false;
+    const normalized=normalizedTextOf(el);
+    if(!normalized)return false;
+    return hints.some(h=>normalized.includes(h));
+  };
+  const setDateTextHints=['来場日時を設定する','来場日時を設定'];
+  const changeTextHints=['来場日時を変更する','来場日時を変更'];
+  const matchesSetDateText=el=>matchesHints(el,setDateTextHints);
+  const matchesChangeText=el=>matchesHints(el,changeTextHints);
+  const changeBtnSelectors=[
+    'div[role="status"] button.style_next_button__N_pbs',
+    'div[role="status"] button[data-message-code="SW_GP_DL_117_0413"]',
+    'div[role="status"] button',
+    'div.style_main__button__fac_Z button.style_next_button__N_pbs',
+    'div.style_main__button__fac_Z button',
+    'div[class*="toast"] button.style_next_button__N_pbs',
+    'div[class*="toast"] button',
+    'button.style_next_button__N_pbs',
+    'button[data-message-code="SW_GP_DL_117_0413"]'
+  ];
+  const findChangeBtn=(exclude=new Set())=>{
+    for(const sel of changeBtnSelectors){
+      const candidates=A(sel);
+      if(!candidates.length)continue;
+      for(const el of candidates){
+        if(exclude.has(el))continue;
+        if(!isEnabled(el)||!vis(el))continue;
+        if(matchesChangeText(el))return el;
+      }
+    }
+    return null;
+  };
   KC(b);
+  clickedButtons.add(b);
+  if(selectedDateISO()!==targetISO)return false;
+  if(matchesSetDateText(b)){
+    let changeBtn=findChangeBtn(clickedButtons);
+    if(!changeBtn){
+      changeBtn=await waitUntil(()=>findChangeBtn(clickedButtons),{
+        timeout:5000,
+        interval:80,
+        attrs:['class','style','aria-hidden','data-disabled','data-message-code']
+      });
+    }
+    if(changeBtn){
+      KC(changeBtn);
+      clickedButtons.add(changeBtn);
+    }
+  }
   if(selectedDateISO()!==targetISO)return false;
   const confirmSelList=['button.style_next_button__N_pbs','button:has(span.btn-text), a:has(span.btn-text)'];
   for(const sel of confirmSelList){
+    const existing=typeof sel==='string'?Q(sel):sel;
+    if(existing&&clickedButtons.has(existing))continue;
     const c=await waitEnabled(sel,8000);
-    if(c){ KC(c); break; }
+    if(!c||clickedButtons.has(c))continue;
+    KC(c);
+    clickedButtons.add(c);
+    break;
   }
   return true;
 }


### PR DESCRIPTION
## 目的 / Purpose
- Legacy スクリプトでもトーストで表示される「来場日時を変更する」ボタンを自動で押下し、予約フローを途切れさせないようにする。

## 変更点 / Changes
- 予約確定フローでボタンの文言を解析し、日時設定直後にトーストの変更ボタンが出現した場合は即時クリックするよう対応。
- 重複クリックを避けるために Legacy 版でもクリック済みボタンを追跡して次の操作ボタンを選別。

## テスト / Test
- [ ] ローカルで Tampermonkey にインストールして動作確認
- [ ] main ページ / 予約ページの描画遅延に対する耐性確認
- [ ] 10月ページ送り（nextMonth）確認

## メモ / Notes
- 手元に確認環境がないため未実施です。


------
https://chatgpt.com/codex/tasks/task_e_68dde8fea8e48327842e815b70425087