### PR TITLE
Display script version labels in all user script UIs

### DIFF
--- a/Legacy-expo2025-ios.user.js
+++ b/Legacy-expo2025-ios.user.js
@@ -1,5 +1,7 @@
 (function(){'use strict';
 
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -692,13 +694,20 @@ const ui=(()=>{
     return d;
   };
   const rTop=row();
+  const titleBox=document.createElement('div');
+  Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
   const title=document.createElement('div');
   title.textContent='自動新規予約';
   title.style.fontWeight='bold';
+  const version=document.createElement('span');
+  version.textContent=`v${SCRIPT_VERSION}`;
+  Object.assign(version.style,{fontSize:'11px',color:'#555'});
+  titleBox.appendChild(title);
+  titleBox.appendChild(version);
   const tg=document.createElement('input');
   tg.type='checkbox';
   tg.checked=!!state.r;
-  rTop.appendChild(title);
+  rTop.appendChild(titleBox);
   rTop.appendChild(tg);
   const rTime=row(6);
   const labT=document.createElement('label');

--- a/Legacy-expo2025.js
+++ b/Legacy-expo2025.js
@@ -14,6 +14,8 @@
 
 (function(){'use strict';
 
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -695,13 +697,20 @@ const ui=(()=>{
     return d;
   };
   const rTop=row();
+  const titleBox=document.createElement('div');
+  Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
   const title=document.createElement('div');
   title.textContent='自動新規予約';
   title.style.fontWeight='bold';
+  const version=document.createElement('span');
+  version.textContent=`v${SCRIPT_VERSION}`;
+  Object.assign(version.style,{fontSize:'11px',color:'#555'});
+  titleBox.appendChild(title);
+  titleBox.appendChild(version);
   const tg=document.createElement('input');
   tg.type='checkbox';
   tg.checked=!!state.r;
-  rTop.appendChild(title);
+  rTop.appendChild(titleBox);
   rTop.appendChild(tg);
   const rTime=row(6);
   const labT=document.createElement('label');

--- a/expo2025-reserver-android.user.js
+++ b/expo2025-reserver-android.user.js
@@ -11,6 +11,8 @@
 // @supportURL   https://github.com/expo2025-auto/expo2025-tm-autobooker/issues
 // ==/UserScript==
 
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -1275,9 +1277,12 @@ ui=(()=>{const w=document.createElement('div');
 Object.assign(w.style,{position:'fixed',bottom:'20px',right:'20px',zIndex:999999,background:'rgba(255,255,255,.95)',padding:'10px 12px',borderRadius:'12px',boxShadow:'0 2px 10px rgba(0,0,0,.2)',fontFamily:'-apple-system,system-ui,Segoe UI,Roboto,sans-serif',width:'320px'});
 const row=m=>{const d=document.createElement('div');Object.assign(d.style,{display:'flex',gap:'8px',alignItems:'center',marginBottom:(m??8)+'px'});return d};
 const rTop=row();
+const titleBox=document.createElement('div');Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
 const title=document.createElement('div');title.textContent='自動新規予約';title.style.fontWeight='bold';
+const version=document.createElement('span');version.textContent=`v${SCRIPT_VERSION}`;Object.assign(version.style,{fontSize:'11px',color:'#555'});
+titleBox.appendChild(title);titleBox.appendChild(version);
 const tg=document.createElement('input');tg.type='checkbox';tg.checked=!!state.r;
-rTop.appendChild(title);rTop.appendChild(tg);
+rTop.appendChild(titleBox);rTop.appendChild(tg);
 const keepRow=row();
 const keepLabelBox=document.createElement('label');Object.assign(keepLabelBox.style,{display:'flex',alignItems:'center',gap:'6px',fontSize:'12px',flex:'1'});
 const keepText=document.createElement('span');keepText.textContent='ログイン維持用リロードON・OFF';

--- a/expo2025-reserver-change-test.user.js
+++ b/expo2025-reserver-change-test.user.js
@@ -11,6 +11,8 @@
 // @supportURL   https://github.com/expo2025-auto/expo2025-tm-autobooker/issues
 // ==/UserScript==
 
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -1267,9 +1269,12 @@ ui=(()=>{const w=document.createElement('div');
 Object.assign(w.style,{position:'fixed',bottom:'20px',right:'20px',zIndex:999999,background:'rgba(255,255,255,.95)',padding:'10px 12px',borderRadius:'12px',boxShadow:'0 2px 10px rgba(0,0,0,.2)',fontFamily:'-apple-system,system-ui,Segoe UI,Roboto,sans-serif',width:'320px'});
 const row=m=>{const d=document.createElement('div');Object.assign(d.style,{display:'flex',gap:'8px',alignItems:'center',marginBottom:(m??8)+'px'});return d};
 const rTop=row();
+const titleBox=document.createElement('div');Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
 const title=document.createElement('div');title.textContent='自動新規予約';title.style.fontWeight='bold';
+const version=document.createElement('span');version.textContent=`v${SCRIPT_VERSION}`;Object.assign(version.style,{fontSize:'11px',color:'#555'});
+titleBox.appendChild(title);titleBox.appendChild(version);
 const tg=document.createElement('input');tg.type='checkbox';tg.checked=!!state.r;
-rTop.appendChild(title);rTop.appendChild(tg);
+rTop.appendChild(titleBox);rTop.appendChild(tg);
 const keepRow=row();
 const keepLabelBox=document.createElement('label');Object.assign(keepLabelBox.style,{display:'flex',alignItems:'center',gap:'6px',fontSize:'12px',flex:'1'});
 const keepText=document.createElement('span');keepText.textContent='ログイン維持用リロードON・OFF';

--- a/expo2025-reserver-ios.user.js
+++ b/expo2025-reserver-ios.user.js
@@ -1,3 +1,5 @@
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -1244,9 +1246,12 @@ ui=(()=>{const w=document.createElement('div');
 Object.assign(w.style,{position:'fixed',bottom:'20px',right:'20px',zIndex:999999,background:'rgba(255,255,255,.95)',padding:'10px 12px',borderRadius:'12px',boxShadow:'0 2px 10px rgba(0,0,0,.2)',fontFamily:'-apple-system,system-ui,Segoe UI,Roboto,sans-serif',width:'320px'});
 const row=m=>{const d=document.createElement('div');Object.assign(d.style,{display:'flex',gap:'8px',alignItems:'center',marginBottom:(m??8)+'px'});return d};
 const rTop=row();
+const titleBox=document.createElement('div');Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
 const title=document.createElement('div');title.textContent='自動新規予約';title.style.fontWeight='bold';
+const version=document.createElement('span');version.textContent=`v${SCRIPT_VERSION}`;Object.assign(version.style,{fontSize:'11px',color:'#555'});
+titleBox.appendChild(title);titleBox.appendChild(version);
 const tg=document.createElement('input');tg.type='checkbox';tg.checked=!!state.r;
-rTop.appendChild(title);rTop.appendChild(tg);
+rTop.appendChild(titleBox);rTop.appendChild(tg);
 const keepRow=row();
 const keepLabelBox=document.createElement('label');Object.assign(keepLabelBox.style,{display:'flex',alignItems:'center',gap:'6px',fontSize:'12px',flex:'1'});
 const keepText=document.createElement('span');keepText.textContent='ログイン維持用リロードON・OFF';

--- a/expo2025-reserver.user.js
+++ b/expo2025-reserver.user.js
@@ -11,6 +11,8 @@
 // @supportURL   https://github.com/expo2025-auto/expo2025-tm-autobooker/issues
 // ==/UserScript==
 
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -1295,9 +1297,12 @@ ui=(()=>{const w=document.createElement('div');
 Object.assign(w.style,{position:'fixed',bottom:'20px',right:'20px',zIndex:999999,background:'rgba(255,255,255,.95)',padding:'10px 12px',borderRadius:'12px',boxShadow:'0 2px 10px rgba(0,0,0,.2)',fontFamily:'-apple-system,system-ui,Segoe UI,Roboto,sans-serif',width:'320px'});
 const row=m=>{const d=document.createElement('div');Object.assign(d.style,{display:'flex',gap:'8px',alignItems:'center',marginBottom:(m??8)+'px'});return d};
 const rTop=row();
+const titleBox=document.createElement('div');Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
 const title=document.createElement('div');title.textContent='自動新規予約';title.style.fontWeight='bold';
+const version=document.createElement('span');version.textContent=`v${SCRIPT_VERSION}`;Object.assign(version.style,{fontSize:'11px',color:'#555'});
+titleBox.appendChild(title);titleBox.appendChild(version);
 const tg=document.createElement('input');tg.type='checkbox';tg.checked=!!state.r;
-rTop.appendChild(title);rTop.appendChild(tg);
+rTop.appendChild(titleBox);rTop.appendChild(tg);
 const keepRow=row();
 const keepLabelBox=document.createElement('label');Object.assign(keepLabelBox.style,{display:'flex',alignItems:'center',gap:'6px',fontSize:'12px',flex:'1'});
 const keepText=document.createElement('span');keepText.textContent='ログイン維持用リロードON・OFF';

--- a/simple-clock.js
+++ b/simple-clock.js
@@ -9,9 +9,14 @@
 // ==/UserScript==
 
 (() => {
+  const SCRIPT_VERSION = (typeof GM_info !== 'undefined' && GM_info?.script?.version) || 'dev';
   const CLOCK_ID = 'simple-clock';
+  const CLOCK_TIME_CLASS = 'simple-clock__time';
+  const CLOCK_VERSION_CLASS = 'simple-clock__version';
   const SYNC_ENDPOINT = window.location.origin;
   let clockElement = null;
+  let timeDisplay = null;
+  let versionDisplay = null;
 
   let offset = 0;
   let syncTimeoutId = null;
@@ -24,7 +29,10 @@
     const hours = pad(now.getHours());
     const minutes = pad(now.getMinutes());
     const seconds = pad(now.getSeconds());
-    ensureClockElement().textContent = `${hours}:${minutes}:${seconds}`;
+    ensureClockElement();
+    if (timeDisplay) {
+      timeDisplay.textContent = `${hours}:${minutes}:${seconds}`;
+    }
   };
 
   const scheduleNextSync = () => {
@@ -68,6 +76,7 @@
 
   const ensureClockElement = () => {
     if (clockElement && document.body.contains(clockElement)) {
+      ensureClockStructure(clockElement);
       return clockElement;
     }
 
@@ -75,6 +84,7 @@
     if (existing && document.body.contains(existing)) {
       clockElement = existing;
       applyClockStyles(clockElement);
+      ensureClockStructure(clockElement);
       return clockElement;
     }
 
@@ -83,6 +93,7 @@
     applyClockStyles(el);
     document.body.appendChild(el);
     clockElement = el;
+    ensureClockStructure(el);
     return clockElement;
   };
 
@@ -92,8 +103,10 @@
     el.style.top = '50%';
     el.style.transform = 'translateY(-50%)';
     el.style.fontFamily = 'monospace';
-    el.style.fontSize = '2rem';
-    el.style.letterSpacing = '0.1em';
+    el.style.display = 'flex';
+    el.style.flexDirection = 'column';
+    el.style.alignItems = 'flex-start';
+    el.style.gap = '0.25rem';
     el.style.textAlign = 'left';
     el.style.padding = '0.5rem 1rem';
     el.style.background = 'rgba(0, 0, 0, 0.65)';
@@ -103,6 +116,45 @@
     el.style.zIndex = '2147483647';
     el.style.pointerEvents = 'none';
     el.style.userSelect = 'none';
+  }
+
+  function applyTimeStyles(el) {
+    el.style.fontSize = '2rem';
+    el.style.letterSpacing = '0.1em';
+    el.style.lineHeight = '1';
+  }
+
+  function applyVersionStyles(el) {
+    el.style.fontSize = '0.75rem';
+    el.style.opacity = '0.8';
+    el.style.letterSpacing = '0.05em';
+  }
+
+  function ensureClockStructure(el) {
+    if (!el) {
+      return;
+    }
+    timeDisplay = el.querySelector(`.${CLOCK_TIME_CLASS}`);
+    if (!timeDisplay) {
+      timeDisplay = document.createElement('div');
+      timeDisplay.className = CLOCK_TIME_CLASS;
+      applyTimeStyles(timeDisplay);
+      el.appendChild(timeDisplay);
+    } else {
+      applyTimeStyles(timeDisplay);
+    }
+
+    versionDisplay = el.querySelector(`.${CLOCK_VERSION_CLASS}`);
+    if (!versionDisplay) {
+      versionDisplay = document.createElement('div');
+      versionDisplay.className = CLOCK_VERSION_CLASS;
+      applyVersionStyles(versionDisplay);
+      el.appendChild(versionDisplay);
+    } else {
+      applyVersionStyles(versionDisplay);
+    }
+
+    versionDisplay.textContent = `v${SCRIPT_VERSION}`;
   }
 
   const init = () => {

--- a/v2-8-expo2025-reserver.user.js
+++ b/v2-8-expo2025-reserver.user.js
@@ -11,6 +11,8 @@
 // @supportURL   https://github.com/expo2025-auto/expo2025-tm-autobooker/issues
 // ==/UserScript==
 
+const SCRIPT_VERSION=(typeof GM_info!=='undefined'&&GM_info?.script?.version)||'dev';
+
 /* ========= ユーティリティ ========= */
 const CONF_KEY='nr_conf_v1',STATE_KEY='nr_state_v1';
 function Lget(k){try{return JSON.parse(localStorage.getItem(k)||'{}')}catch{return{}}}
@@ -960,9 +962,12 @@ ui=(()=>{const w=document.createElement('div');
 Object.assign(w.style,{position:'fixed',bottom:'20px',right:'20px',zIndex:999999,background:'rgba(255,255,255,.95)',padding:'10px 12px',borderRadius:'12px',boxShadow:'0 2px 10px rgba(0,0,0,.2)',fontFamily:'-apple-system,system-ui,Segoe UI,Roboto,sans-serif',width:'320px'});
 const row=m=>{const d=document.createElement('div');Object.assign(d.style,{display:'flex',gap:'8px',alignItems:'center',marginBottom:(m??8)+'px'});return d};
 const rTop=row();
+const titleBox=document.createElement('div');Object.assign(titleBox.style,{display:'flex',alignItems:'baseline',gap:'6px',flex:'1'});
 const title=document.createElement('div');title.textContent='自動新規予約';title.style.fontWeight='bold';
+const version=document.createElement('span');version.textContent=`v${SCRIPT_VERSION}`;Object.assign(version.style,{fontSize:'11px',color:'#555'});
+titleBox.appendChild(title);titleBox.appendChild(version);
 const tg=document.createElement('input');tg.type='checkbox';tg.checked=!!state.r;
-rTop.appendChild(title);rTop.appendChild(tg);
+rTop.appendChild(titleBox);rTop.appendChild(tg);
 const keepRow=row();
 const keepLabelBox=document.createElement('label');Object.assign(keepLabelBox.style,{display:'flex',alignItems:'center',gap:'6px',fontSize:'12px',flex:'1'});
 const keepText=document.createElement('span');keepText.textContent='ログイン維持用リロードON・OFF';


### PR DESCRIPTION
## Summary
- display the current script version within every reservation helper panel header using the available Tampermonkey metadata
- update the simple clock overlay to show its version alongside the time while preserving styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddfd0913dc83278af8b45434c61f06