### PR TITLE
Avoid reload on render timeout

### DIFF
--- a/v2-8-slowly-expo2025-reserver.user-ios.js
+++ b/v2-8-slowly-expo2025-reserver.user-ios.js
@@ -72,14 +72,16 @@ function renderReady(){
 async function waitForRenderReady(timeout=RENDER_READY_TIMEOUT_MS){
   const start=Date.now();
   while(Date.now()-start<timeout){
-    if(renderReady())break;
+    if(renderReady()){await waitFrames(RENDER_READY_EXTRA_FRAMES);return true;}
     await waitMs(RENDER_READY_CHECK_INTERVAL);
   }
-  await waitFrames(RENDER_READY_EXTRA_FRAMES);
+  return false;
 }
 async function reloadAfterRender({requireActive=true,resetFailCount=true}={}){
   if(requireActive&&!state.r)return;
-  try{await waitForRenderReady()}catch{}
+  let ready=false;
+  try{ready=await waitForRenderReady()}catch{}
+  if(!ready)return;
   if(resetFailCount)try{resetFail()}catch{}
   queueSafeReload(RELOAD_DELAY_OFFSET_MS);
 }


### PR DESCRIPTION
## Summary
- make render readiness check report success instead of always forcing a reload
- only queue reloads when the readiness check succeeds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df396a7d308327849b3e2d35c1859a