### PR TITLE
Add ticket site support to NR debug logger

### DIFF
--- a/nr-debug-logger.user.js
+++ b/nr-debug-logger.user.js
@@ -5,6 +5,7 @@
 // @description  Collects detailed runtime logs to help diagnose unexpected reloads and navigation in Expo2025 NR scripts.
 // @match        https://reserve.expo2025.or.jp/*
 // @match        https://reserve-visitor.expo2025.or.jp/*
+// @match        https://ticket.expo2025.or.jp/*
 // @run-at       document-start
 // @grant        GM_registerMenuCommand
 // @grant        GM_setClipboard
@@ -24,6 +25,7 @@
   const TOP_PAGE_PATTERNS = [
     /^https:\/\/reserve\.expo2025\.or\.jp\/?(?:[?#]|$)/i,
     /^https:\/\/reserve-visitor\.expo2025\.or\.jp\/?(?:[?#]|$)/i,
+    /^https:\/\/ticket\.expo2025\.or\.jp\/?(?:[?#]|$)/i,
   ];
 
   const state = {

--- a/nr-debug-logger.user.js
+++ b/nr-debug-logger.user.js
@@ -9,6 +9,9 @@
 // @run-at       document-start
 // @grant        GM_registerMenuCommand
 // @grant        GM_setClipboard
+// @updateURL    https://github.com/expo2025-auto/expo2025-tm-autobooker/raw/refs/heads/main/nr-debug-logger.user.js
+// @downloadURL  https://github.com/expo2025-auto/expo2025-tm-autobooker/raw/refs/heads/main/nr-debug-logger.user.js
+// @supportURL   https://github.com/expo2025-auto/expo2025-tm-autobooker/issues
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
## Summary
- allow the NR debug logger userscript to run on the Expo 2025 ticket site
- include the ticket portal in the top page detection patterns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e09719d7648327b0a9a1216063a11b