### PR TITLE
Reduce fail toast wait

### DIFF
--- a/v2-8-expo2025-reserver-ultrafast.user.js
+++ b/v2-8-expo2025-reserver-ultrafast.user.js
@@ -328,7 +328,11 @@ function hasFailToast(){
 }
 ;(function armFastFailReload(){
   let armed=false;
-  const kick=()=>{if(armed)return;armed=true;setTimeout(()=>{if(hasFailToast())robustReload()},500)};
+  const kick=()=>{
+    if(armed)return;
+    armed=true;
+    setTimeout(()=>{if(hasFailToast())robustReload()},0);
+  };
   const mo=new MutationObserver(muts=>{
     for(const m of muts){
       if(m.type==='childList'){


### PR DESCRIPTION
## Summary
- trigger the fail toast recovery immediately instead of waiting half a second

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8b866a5488327a2dd91096abac61d